### PR TITLE
Fixed grammatical errors and spelling mistakes

### DIFF
--- a/articles/static-web-apps/overview.md
+++ b/articles/static-web-apps/overview.md
@@ -16,39 +16,39 @@ ms.locfileid: "87835790"
 ---
 # <a name="what-is-azure-static-web-apps-preview"></a>Vad är Azures statiska Web Apps för hands version?
 
-Azures statiska Web Apps är en tjänst som automatiskt skapar och distribuerar fullständiga stack-webbappar till Azure från en GitHub-lagringsplats.
+Azure Static Web Apps är en tjänst som automatiskt skapar och distribuerar fullstack webbappar till Azure från ett GitHub repository.
 
 :::image type="content" source="media/overview/static-apps-overview.png" alt-text="Översikt över statiska Web Apps":::
 
-Arbets flödet för den statiska Azure-Web Apps är anpassat till en utvecklares dagliga arbets flöde. Appar skapas och distribueras baserat på GitHub-interaktioner.
+Arbetsflödet för Azure Static Web Apps är anpassat till en utvecklares dagliga arbetsflöde. Appar skapas och distribueras baserat på GitHub interaktioner.
 
-När du skapar en Azure Static Web Apps-resurs skapar Azure ett GitHub Actions-arbetsflöde på lagringsplatsen för appens källkod som övervakar den gren som du har valt. Varje gång du push-skickar eller accepterar pull-begäranden till den bevakade grenen skapar och distribuerar GitHub-åtgärden automatiskt appen och dess API till Azure.
+När du skapar en Azure Static Web Apps-resurs skapar Azure ett GitHub Actions-arbetsflöde på lagringsplatsen för appens källkod (repository) som övervakar den gren som du har valt. Varje gång du push-skickar eller accepterar pull-begäranden till den bevakade grenen skapar och distribuerar GitHub Actions automatiskt appen och dess API till Azure.
 
-Statiska webbappar skapas vanligtvis med hjälp av bibliotek och ramverk som Angular, React, Svelte eller Vue. Dessa appar består av HTML, CSS, JavaScript och bildtillgångar. Med en traditionell webb server betjänas dessa till gångar från en enda server tillsammans med eventuella nödvändiga API-slutpunkter.
+Statiska webbappar skapas vanligtvis med hjälp av bibliotek och ramverk som Angular, React, Svelte eller Vue. Dessa appar består av HTML, CSS, JavaScript och bildtillgångar. Med en traditionell webbserver betjänas dessa tillgångar från en enda server tillsammans med eventuella nödvändiga API-ändpunkter.
 
-Med statiska Web Apps separeras statiska till gångar från en traditionell webb server och betjänas i stället från platser geografiskt fördelade över hela världen. Den här distributionen gör att det går mycket snabbare att hantera filer eftersom filerna är fysiskt närmare slutanvändarna. Dessutom är API-slutpunkterna värdbaserade med en [arkitektur utan server](../azure-functions/functions-overview.md), vilket gör att du inte behöver ha en fullständig backend-server samtidigt.
+Med Azure Static Web Apps separeras statiska tillgångar från en traditionell webbserver och betjänas i stället från platser geografiskt fördelade över hela världen. Den här distributionen gör att det går mycket snabbare att hantera filer eftersom filerna är fysiskt närmare slutanvändarna. Dessutom är API-ändpunkterna hostade med en [serverless arkitektur](../azure-functions/functions-overview.md), vilket gör att du inte behöver ha en fullständig backend-server samtidigt.
 
 ## <a name="key-features"></a>Huvudfunktioner
 
-- **Webb värd** för statiskt innehåll som HTML, CSS, Java Script och avbildningar.
+- **Webbvärd** för statiskt innehåll som HTML, CSS, Java Script och bilder.
 - **Inbyggt API** -stöd som tillhandahålls av Azure Functions.
 - **GitHub-integration från första part** där lagrings ändringar utlöser versioner och distributioner.
-- **Globalt distribuerat** statiskt innehåll, vilket ger innehållet närmare dina användare.
-- **Kostnads fria SSL-certifikat**, som automatiskt förnyas.
-- **Anpassade domäner** \* för att tillhandahålla anpassade anpassningar till din app.
-- **Sömlös säkerhets modell** med en omvänd proxy vid anrop till API: er som inte kräver CORS-konfiguration.
+- **Globalt distribuerat** statiskt innehåll, vilket gör att innehållet serveras närmare dina användare.
+- **Kostnadsfria SSL-certifikat**, som automatiskt förnyas.
+- **Självvalda domäner** \* för att styrka appens varumärke.
+- **Sömlös säkerhetsmodell** med en omvänd proxy vid anrop till API:er som inte kräver CORS-konfiguration.
 - **Integrering av autentiseringsprovider** med Azure Active Directory, Facebook, Google, GitHub och Twitter.
 - **Anpassningsbar roll definition** och tilldelningar för auktorisering.
-- **Regler för routning på Server sidan** möjliggör fullständig kontroll över det innehåll och de vägar som du hanterar.
+- **Regler för routning på serversidan** möjliggör fullständig kontroll över det innehåll och routes som du hanterar.
 - **Genererade produktions versioner** som drivs av pull-begäranden som aktiverar för hands versioner av din webbplats innan publicering.
 
-## <a name="what-you-can-do-with-static-web-apps"></a>Vad du kan göra med statiska Web Apps
+## <a name="what-you-can-do-with-static-web-apps"></a>Vad du kan göra med Static Web Apps
 
 - **Bygg moderna JavaScript-program** med ramverk och bibliotek som [vinkel](getting-started.md#tabpanel_CeZOj-G++Q_angular), [reagera](getting-started.md#tabpanel_CeZOj-G++Q_react), [svelte](https://docs.microsoft.com/learn/modules/publish-app-service-static-web-app-api/), [Vue](getting-started.md#tabpanel_CeZOj-G++Q_vue) med en [Azure Functions](apis.md) backend.
-- **Publicera statiska platser** med ramverk som [Gatsby](publish-gatsby.md), [Hugo](publish-hugo.md), [VuePress](publish-vuepress.md).
-- **Distribuera webb program** med ramverk som [Next.js](deploy-nextjs.md) och [Nuxt.js](deploy-nuxtjs.md).
+- **Publicera statiska sidor** med ramverk som [Gatsby](publish-gatsby.md), [Hugo](publish-hugo.md), [VuePress](publish-vuepress.md).
+- **Distribuera webbprogram** med ramverk som [Next.js](deploy-nextjs.md) och [Nuxt.js](deploy-nuxtjs.md).
 
-\*Spetsig domän registreringar stöds inte under för hands versionen.
+\*Apex-domän registreringar stöds inte under förhandsversionen.
 
 ## <a name="next-steps"></a>Nästa steg
 


### PR DESCRIPTION
The original translation (machine translated I believe) made no sense and I've done my best to improve the translation. We use a lot of loanwords from English that do not have a direct Swedish translation (for example' hosting' and 'repository') and these are best left as-is instead of forcing a direct translation. 

I've kept the wording as close as possible to the English version, and although further improvements can be made, this is a good start.

There is no corresponding issue to this pull request, let me know if you prefer there to be one.